### PR TITLE
[fix] movieName regexp 변경

### DIFF
--- a/src/main/java/com/sopt/cds5/controller/dto/request/MovieRequestDto.java
+++ b/src/main/java/com/sopt/cds5/controller/dto/request/MovieRequestDto.java
@@ -17,7 +17,7 @@ public class MovieRequestDto { //create에 필요한 dto입니다.
     private Long movieId;
 
     @NotNull(message = "영화제목이 존재하지 않습니다.")
-    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,20}$", message = "영화제목 형식에 맞지 않습니다.")
+    @Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "영화제목 형식에 맞지 않습니다.")
     private String movieName;
     @NotNull(message = "예매율이 존재하지 않습니다.")
     private float reservationRatio;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #13 

## 📋 구현 기능 명세
- [x] movieName regexp 패턴 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
영화제목에 공백이 안들어가는 현상이 발생하여 나중에 서버끼리 작업할 때 불편한 일이 일어날 수 있다고 생각함.

- 어떤 부분에 리뷰어가 집중해야 하는지
추가로 정규표현식에 필요한 것이 있을지

- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "영화제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /movie/create
